### PR TITLE
fix(Arktype/formDataToObject): Opens up the matching algorithm to any string value

### DIFF
--- a/.changeset/dry-radios-raise.md
+++ b/.changeset/dry-radios-raise.md
@@ -1,0 +1,8 @@
+---
+'@jhecht/arktype-utils': patch
+---
+
+Fixes bug in key detection algorithm for formDataToObject
+
+Previously the keys were limited to only alpha-based characters, which does not follow JavaScript's own
+way of dealing with keys in objects. This was opened up, allowing for any string value to be used as the key.

--- a/packages/arktype-utils/src/formData.ts
+++ b/packages/arktype-utils/src/formData.ts
@@ -8,7 +8,7 @@ type FilterFn = (a: EntriesTouple) => boolean;
 
 type FormDataObjectEntry = FormDataEntryValue | number | boolean | bigint;
 
-const nameKeyExtractor = /(?<name>[a-zA-z]+[a-zA-Z-]+)\[(?<index>.*)\]/;
+const nameKeyExtractor = /(?<name>.*)\[(?<index>.*)\]/;
 const digitCheck = /^\d+$/;
 
 type MagicObject = {


### PR DESCRIPTION
Allow any string value for keys in formDataToObject

Previously was limited to only alpha-based characters with hyphens, preventing many valid JavaScript object keys from being used