### PR TITLE
fix(Arktype): Updates return type on validateFormData

### DIFF
--- a/.changeset/itchy-owls-learn.md
+++ b/.changeset/itchy-owls-learn.md
@@ -1,0 +1,8 @@
+---
+'@jhecht/arktype-utils': patch
+---
+
+Fixes type for validateFormData function.
+
+Previously the type was set incorrectly to use `Type['infer']` and not 
+`T['infer']`, as it should have been. The dangers of writing and reviewing your own code!

--- a/packages/arktype-utils/src/formData.ts
+++ b/packages/arktype-utils/src/formData.ts
@@ -151,7 +151,7 @@ export function validateFormData<T extends Type<any, any>>(
   obj: T,
   filterFn?: FilterFn,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): Type['infer'] {
+): T['infer'] {
   const fdo = formDataToObject(fd, filterFn);
   return obj.assert(fdo);
 }


### PR DESCRIPTION
Fixed incorrect type inference in `validateFormData`

Previous type used `Type['infer']` when it should have used `T['infer']`