### PR TITLE
ci: Add publishing workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: pnpm/action-setup@v2
         name: Install PNPM
         with:
-          versions: 8
+          version: 9
       - uses: actions/cache@v3
         name: setup PNPM cache
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,50 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      NPM_CONFIG_PROVENANCE: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        name: Install PNPM
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          registry-url: 'https://registry.npmjs.org'
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Changesets version
+        run: pnpm changeset:version
+
+      - name: Commit version changes
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add .
+          git commit -m "chore(release): Publish packages"
+          git push --follow-tags
+
+      - name: Run Changesets publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm changeset:publish

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "publish-packages": "turbo run build lint test && changeset version && changeset publish",
     "test": "turbo run test",
     "test:changed": "turbo run --filter=[main...HEAD] test:ci",
-    "changeset:ci": "changeset status"
+    "changeset:ci": "changeset status",
+    "changeset:version": "changeset version",
+    "changeset:publish": "changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",


### PR DESCRIPTION
## Tl;Dr

Adds in publishing workflow to publish packages from GitHub without needing to remember the steps myself.

## Summary

1. Adds in a publish.yml file that can be manually triggered. Job will run the changeset version script, commit the changes, and push a publish commit along with tags. Then publishes the projects. Hopefully with provedence