### PR TITLE
fix(arktype-utils): Adjusts bad values to stop mangling names

### DIFF
--- a/.changeset/angry-pots-cross.md
+++ b/.changeset/angry-pots-cross.md
@@ -1,0 +1,5 @@
+---
+"@jhecht/arktype-utils": patch
+---
+
+Fixes faulty logic in parse key causing names to only be the first character.

--- a/packages/arktype-utils/CHANGELOG.md
+++ b/packages/arktype-utils/CHANGELOG.md
@@ -13,17 +13,17 @@
   ```ts
   // Test nested objects with dot notation
   const fd = new FormData();
-  fd.append("payments.id1.location", "England");
-  fd.append("payments.id1.age", "37");
-  fd.append("payments.id2.location", "New York");
+  fd.append('payments.id1.location', 'England');
+  fd.append('payments.id1.age', '37');
+  fd.append('payments.id2.location', 'New York');
   const obj = formDataToObject(fd);
 
   // Test nested arrays with bracket notation
   const fd2 = new FormData();
-  fd2.append("locations[].name", "England");
-  fd2.append("locations[].members[]", "John");
-  fd2.append("locations[].members[]", "Joe");
-  fd2.append("locations[].name", "France");
+  fd2.append('locations[].name', 'England');
+  fd2.append('locations[].members[]', 'John');
+  fd2.append('locations[].members[]', 'Joe');
+  fd2.append('locations[].name', 'France');
   const obj2 = formDataToObject(fd2);
   ```
 

--- a/packages/arktype-utils/package.json
+++ b/packages/arktype-utils/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "test": "vitest --coverage",
-    "test:ci": "vitest run --coverage --changed",
+    "test:ci": "vitest run --coverage",
     "build": "tsup src/index.ts --format cjs,esm --dts",
     "lint": "eslint src/**/*.ts",
     "prepublishOnly": "pnpm run build"

--- a/packages/arktype-utils/src/formData.ts
+++ b/packages/arktype-utils/src/formData.ts
@@ -57,7 +57,8 @@ function parseKeyPath(key: string): (string | number)[] {
   let buffer = '';
   let inBracket = false;
   for (let i = 0; i < key.length; i++) {
-    const [char] = key;
+    // eslint-disable-next-line @jhecht/prefer-destructuring
+    const char = key[i];
     if (char === '[') {
       if (buffer) {
         path.push(buffer);


### PR DESCRIPTION
### TL;DR

Fixed a bug in the form data parser and removed the `--changed` flag from the test:ci script.

### What changed?

- Fixed a critical bug in the `parseKeyPath` function where it was always using the first character of the key instead of iterating through each character
- Removed the `--changed` flag from the `test:ci` script in package.json to ensure all tests run during CI

### How to test?

1. Run `pnpm test` to verify the form data parser works correctly
2. Test with a form data key that contains brackets to ensure proper parsing
3. Verify CI tests run all tests instead of only changed files

### Why make this change?

The form data parser had a critical bug where it was always using the first character of the key (`key[0]`) instead of the current character in the iteration (`key[i]`). This would cause incorrect parsing of form data keys with brackets. Additionally, removing the `--changed` flag ensures that all tests run during CI, providing better test coverage and preventing potential regressions.