### PR TITLE
fix(arktype-utils): Ensures keys are set on the correct object in an array

### DIFF
--- a/.changeset/popular-falcons-fly.md
+++ b/.changeset/popular-falcons-fly.md
@@ -1,0 +1,5 @@
+---
+"@jhecht/arktype-utils": patch
+---
+
+Fixes bug not grouping items correctly

--- a/packages/arktype-utils/CHANGELOG.md
+++ b/packages/arktype-utils/CHANGELOG.md
@@ -19,17 +19,17 @@
   ```ts
   // Test nested objects with dot notation
   const fd = new FormData();
-  fd.append("payments.id1.location", "England");
-  fd.append("payments.id1.age", "37");
-  fd.append("payments.id2.location", "New York");
+  fd.append('payments.id1.location', 'England');
+  fd.append('payments.id1.age', '37');
+  fd.append('payments.id2.location', 'New York');
   const obj = formDataToObject(fd);
 
   // Test nested arrays with bracket notation
   const fd2 = new FormData();
-  fd2.append("locations[].name", "England");
-  fd2.append("locations[].members[]", "John");
-  fd2.append("locations[].members[]", "Joe");
-  fd2.append("locations[].name", "France");
+  fd2.append('locations[].name', 'England');
+  fd2.append('locations[].members[]', 'John');
+  fd2.append('locations[].members[]', 'Joe');
+  fd2.append('locations[].name', 'France');
   const obj2 = formDataToObject(fd2);
   ```
 

--- a/packages/arktype-utils/src/formData.test.ts
+++ b/packages/arktype-utils/src/formData.test.ts
@@ -118,6 +118,23 @@ describe('formDataToObject', () => {
     const obj = formDataToObject(fd);
     expect(obj.file).toBeInstanceOf(File);
   });
+
+  it('Should work with complex arrays / object combinations', () => {
+    const fd = new FormData();
+    fd.append('bills[].id', 'id1');
+    fd.append('bills[].name', 'Rent');
+    fd.append('bills[].id', 'id2');
+    fd.append('bills[].name', 'Electricity');
+
+    const obj = formDataToObject(fd);
+
+    expect(obj).toStrictEqual({
+      bills: [
+        { id: 'id1', name: 'Rent' },
+        { id: 'id2', name: 'Electricity' },
+      ],
+    });
+  });
 });
 
 describe('formDataToObject - nested keys', () => {


### PR DESCRIPTION
# Fix bug in form data object grouping

Fixes a bug in the `formDataToObject` function where complex arrays and object combinations weren't being grouped correctly. The issue was in the logic that determines when to push the current object to the array and start a new one.

The PR adds a test case for complex array/object combinations and updates the grouping logic to:
- Track the last field processed
- Only push the current object when a non-array field repeats
- Check if the field is an array field before deciding to push

This ensures proper grouping of form data like `bills[].id` and `bills[].name` into structured objects.